### PR TITLE
README: debugImplementationでなければならない理由をもう少し詳しくしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GOGO Screenshot Testの特徴は以下の通りです。
 - [JUnit 5のExtension](https://junit.org/junit5/docs/current/user-guide/#extensions)として提供しています
 - スクリーンショットを撮るテストの書きやすさに注力しています
 - 画面の表示が完了するまで待ち合わせるために必要な[Espresso idling resources](https://developer.android.com/training/testing/espresso/idling-resource)実装のうち、よく使うものを予めセットアップしています
-- 公式に提供されている[FragmentScenario](https://developer.android.com/reference/kotlin/androidx/fragment/app/testing/FragmentScenario)を改善し、Fragment起動時にホストとなるActivityを差し替えられるようにした`AppCompatFragmentScenario`を提供しています。
+- 公式に提供されている[FragmentScenario](https://developer.android.com/reference/kotlin/androidx/fragment/app/testing/FragmentScenario)を改善し、Fragment起動時にホストとなるActivityを差し替えられるようにした`AppCompatFragmentScenario`を提供しています
 
 
 ## セットアップ


### PR DESCRIPTION
`debugImplementation`で依存関係を追加しなければならない理由について、もう少し詳しく記述しました。