### PR TITLE
JitPack対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,22 @@ GOGO Screenshot Testの特徴は以下の通りです。
 
 ## セットアップ
 
-- 導入したいプロジェクトのトップレベルに、本リポジトリをGit submoduleとして登録します  
-  ```sh
-  git submodule add git@github.com:MobilityTechnologies/gogo-screenshot-android.git
+[JitPack](https://jitpack.io/#MobilityTechnologies/gogo-screenshot-android)を使っています。
+
+- トップレベルの`build.gradle`にJitPackリポジトリを登録します  
+  ```groovy
+  allprojects {
+      repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+      }
+  }
   ```
-- 本ライブラリをGradleのモジュールとして登録します
-  - `settings.gradle`  
-    ```groovy
-    include ':gogo-screenshot-android:library'
-    ```
-  - `app/build.gradle`  
+- `app/build.gradle`に依存関係を追加します。  
     ※前述の`AppCompatFragmentScenario`にて利用する`Activity`のデフォルト実装`FragmentTestingActivity`を内部に含んでいます。そのため、`androidTestImplementation`ではなく`debugImplementation`として追加してください  
     ```groovy
     dependencies {
-        debugImplementation project(':gogo-screenshot-android:library')
+        debugImplementation 'com.github.MobilityTechnologies:gogo-screenshot-android:0.0.1'
         ...
     }
     ```

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'maven-publish'
 
 android {
     defaultConfig {
@@ -47,4 +48,42 @@ dependencies {
     implementation "com.google.guava:guava:$guavaAndroidVersion"
     implementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     implementation "com.google.android.gms:play-services-maps:$playServicesMapsVersion"
+}
+
+// Because the components are created only during the afterEvaluate phase, you must
+// configure your publications using the afterEvaluate() lifecycle method.
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                // group と version は jitpack が自動的に付けてくれる
+                artifactId = 'gogo-screenshot-android'
+                pom {
+                    name = 'GOGO Screenshot Test for Android'
+                    description = 'A screenshot test library for Android'
+                    url = 'https://github.com/MobilityTechnologies/gogo-screenshot-android'
+                    licenses {
+                        license {
+                            name = 'Apache License 2.0'
+                            url = 'https://api.github.com/licenses/apache-2.0'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'MobilityTechnologies'
+                            name = 'Mobility Technologies Co., Ltd.'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git://github.com/MobilityTechnologies/gogo-screenshot-android.git'
+                        developerConnection = 'scm:git://github.com/MobilityTechnologies/gogo-screenshot-android.git'
+                        url = 'git://github.com/MobilityTechnologies/gogo-screenshot-android.git'
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
- JitPackで生成されるPOMが正しくなるようにbuild.gradleにPOM記載内容をセットしました。
- READMEをJitPackを利用する手順に書き換えました。

