### PR TITLE
スクリーンショットの連番のカウンターをpublicにし、starting()時にActivityOrFragmentPageのプロパティを初期化するようにした

### DIFF
--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
@@ -57,11 +57,11 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
     /**
      * 同じテストメソッド内で、複数枚のスクリーンショットを撮ったときの連番です。1から始まります。
      */
-    private val snapShotCounter: AtomicInteger = AtomicInteger(1)
+    val snapShotCounter: AtomicInteger = AtomicInteger(1)
     private val snapShot: SnapShot = SnapShot()
 
     override fun starting() {
-        // do nothing
+        snapShotCounter.set(1)
     }
 
     override fun finished() {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
@@ -62,6 +62,8 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
 
     override fun starting() {
         snapShotCounter.set(1)
+        snapShotPageName = null
+        activityOrFragmentScenario = null
     }
 
     override fun finished() {


### PR DESCRIPTION
スクリーンショットの連番のカウンターをpublicにし、
テスト開始時に呼ばれる`starting()`メソッドでActivityOrFragmentPageのプロパティを明示的に初期化/リセットするようにしました

JUnit 5のDynamic Testを使う場合、ExtensionのBeforeEachは全体で1回しか呼ばれないことがわかりました。
そういうケースでは`starting()`と`finished()`を明示的に呼ぶ必要があります。

そのようなケースでも`ActivityOrFragmentPage`とそのサブクラスが正しく動くように、
以下のプロパティを`starting()`で明示的に初期化するようにしました。
- スクリーンショットのファイル名の連番に使われるカウンター `snapShotCounter`
- スクリーンショットのファイル名 `snapShotPageName`
- 画面起動のタイミングで非nullとなる`activityOrFragmentScenario`
