### PR TITLE
スクリーンショットファイル名の命名規則をカスタマイズできるようにしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ android {
 | `screenshotType`| `ScreenshotType` | - | AndroidJUnitRunnerの起動オプション`screenshotType`と同じです |
 | `rootDirectory` | `File`     | `/sdcard/${applicationId}`| スクリーンショットを保存するディレクトリを指定します |
 | `buildFlavorPathComponent` | `String?` | `null` | プロダクトフレーバーが定義されていて、スクリーンショット保存ディレクトリをフレーバーごとに分けたい場合は、フレーバー名を指定してください |
+| `fileNameCreator` | `SnapShotNameCreator` | `SnapShotName.toFileName()` | 独自にカスタマイズしたスクリーンショットのファイル名規則を指定します。<br>詳細は`SnapShotNameCreator`インターフェイス説明を参照してください |
 
 ## スクリーンショットを撮るテストを書く
 

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
@@ -30,7 +30,8 @@ import app.mobilitytechnologies.uitest.extension.UiTestExtension
 import app.mobilitytechnologies.uitest.scenario.ActivityOrFragmentScenario
 import app.mobilitytechnologies.uitest.snapshot.ActivityOrFragmentSnapShotTaker
 import app.mobilitytechnologies.uitest.snapshot.SnapShot
-import app.mobilitytechnologies.uitest.snapshot.SnapShotName
+import app.mobilitytechnologies.uitest.snapshot.SnapShotNameCreator
+import app.mobilitytechnologies.uitest.snapshot.SnapShotOptions
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -59,6 +60,8 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
      */
     val snapShotCounter: AtomicInteger = AtomicInteger(1)
     private val snapShot: SnapShot = SnapShot()
+    private val snapShotNameCreator: SnapShotNameCreator
+        get() = SnapShotOptions.currentSettings.fileNameCreator
 
     override fun starting() {
         snapShotCounter.set(1)
@@ -94,19 +97,21 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
     // ==========================
     override fun captureDisplay(condition: String, optionalDescription: String?, waitUntilIdle: Boolean) {
         if (waitUntilIdle) Espresso.onIdle()
-        val snapShotName = SnapShotName(snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
+        val snapShotFileName = snapShotNameCreator.createFileName(
+                snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
         checkNotNull(activityOrFragmentScenario).onActivity {
-            snapShot.captureDisplay(snapShotName.toFileName())
+            snapShot.captureDisplay(snapShotFileName)
         }
     }
 
     override fun captureActivityOrFragment(condition: String, optionalDescription: String?, waitUntilIdle: Boolean) {
         if (waitUntilIdle) Espresso.onIdle()
-        val snapShotName = SnapShotName(snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
+        val snapShotFileName = snapShotNameCreator.createFileName(
+                snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
         checkNotNull(activityOrFragmentScenario).onActivityOrFragment {
             when (it) {
-                is ActivityOrFragment.Activity -> snapShot.capture(it.activity, snapShotName.toFileName())
-                is ActivityOrFragment.Fragment -> snapShot.capture(it.fragment, snapShotName.toFileName())
+                is ActivityOrFragment.Activity -> snapShot.capture(it.activity, snapShotFileName)
+                is ActivityOrFragment.Fragment -> snapShot.capture(it.fragment, snapShotFileName)
             }
         }
     }
@@ -134,12 +139,13 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
                                                     waitUntilIdle: Boolean,
                                                     func: (ActivityOrFragment<out A, out F>) -> View) {
         if (waitUntilIdle) Espresso.onIdle()
-        val snapShotName = SnapShotName(snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
+        val snapShotFileName = snapShotNameCreator.createFileName(
+                snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
         checkNotNull(activityOrFragmentScenario).onActivityOrFragment {
             val view = func(it)
             when (it) {
-                is ActivityOrFragment.Activity -> snapShot.capture(it.activity, view, snapShotName.toFileName())
-                is ActivityOrFragment.Fragment -> snapShot.capture(it.fragment, view, snapShotName.toFileName())
+                is ActivityOrFragment.Activity -> snapShot.capture(it.activity, view, snapShotFileName)
+                is ActivityOrFragment.Fragment -> snapShot.capture(it.fragment, view, snapShotFileName)
             }
         }
     }

--- a/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShotNameCreator.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShotNameCreator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Mobility Technologies Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.mobilitytechnologies.uitest.snapshot
+
+/**
+ * スクリーンショットのファイル名(拡張子除く)の命名規則を指定します。
+ * スクリーンショットが撮影される度に[createFileName]メソッドが呼び出されます。
+ * その結果返される文字列が、当該スクリーンショットのファイル名になります(拡張子除く)。
+ */
+fun interface SnapShotNameCreator {
+
+    /**
+     * スクリーンショットのファイル名を生成します。
+     *
+     * @param pageName スクリーンショット対象の画面名
+     * @param conditionName スクリーンショット撮影時の条件名
+     * @param counter 同じテストメソッドで複数枚スクリーンショットを撮影した場合の通番
+     * @param optionalDescription さらに詳細な説明(nullの場合もある)
+     */
+    fun createFileName(pageName: String, conditionName: String, counter: Int, optionalDescription: String?): String
+}

--- a/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShotOptions.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShotOptions.kt
@@ -20,7 +20,6 @@ import android.os.Environment
 import androidx.test.platform.app.InstrumentationRegistry
 import app.mobilitytechnologies.uitest.snapshot.SnapShotOptions.Companion.DEFAULT_SETTINGS
 import app.mobilitytechnologies.uitest.snapshot.SnapShotOptions.Companion.INSTRUMENTATION_ARGS_KEY_ENCODE_FILE_NAME
-import app.mobilitytechnologies.uitest.snapshot.SnapShotOptions.Companion.currentSettings
 import java.io.File
 
 /**
@@ -81,7 +80,17 @@ data class SnapShotOptions(
          *
          * このプロパティにフレーバー名を指定すると、他のビルドフレーバーで撮ったスクリーンショットが同じディレクトリに混在するのを防ぐことができます。
          */
-        val buildFlavorPathComponent: String? = null
+        val buildFlavorPathComponent: String? = null,
+
+        /**
+         * スクリーンショットのファイル名の命名規則を指定します。
+         * 詳しくは[SnapShotNameCreator]の説明を参照してください。
+         *
+         * デフォルトでは[SnapShotName.toFileName]メソッドが使われます。
+         */
+        val fileNameCreator: SnapShotNameCreator = SnapShotNameCreator { pageName, conditionName, counter, optionalDescription ->
+            SnapShotName(pageName, conditionName, counter, optionalDescription).toFileName()
+        }
 ) {
     companion object {
         const val INSTRUMENTATION_ARGS_KEY_ENCODE_FILE_NAME = "encodeScreenshotFileName"


### PR DESCRIPTION
スクリーンショットファイル名の命名規則をカスタマイズできるようにしました。
fixed #10 

`SnapShotOptions.fileNameCreator`をデフォルト値から変更することで、好きな命名規則でファイル名を生成することができます。
ファイル名生成時に受けとれる入力は`SnapShotName`コンストラクタと同じ、以下の4項目です。

- `pageName`: スクリーンショット対象の画面名
- `conditionName`: スクリーンショット撮影時の条件名
- `counter`: 同じテストメソッドで複数枚スクリーンショットを撮影した場合の通番
- `optionalDescription`: さらに詳細な説明(nullの場合もある)
