### PR TITLE
DialogFragment全体をキャプチャするcaptureDialogFragmentを追加

### DIFF
--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
@@ -59,8 +59,8 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
      * 同じテストメソッド内で、複数枚のスクリーンショットを撮ったときの連番です。1から始まります。
      */
     val snapShotCounter: AtomicInteger = AtomicInteger(1)
-    protected val snapShot: SnapShot = SnapShot()
-    protected val snapShotNameCreator: SnapShotNameCreator
+    val snapShot: SnapShot = SnapShot()
+    val snapShotNameCreator: SnapShotNameCreator
         get() = SnapShotOptions.currentSettings.fileNameCreator
 
     override fun starting() {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityOrFragmentScenarioPage.kt
@@ -59,8 +59,8 @@ abstract class ActivityOrFragmentScenarioPage<IMPL, A : AppCompatActivity, F : F
      * 同じテストメソッド内で、複数枚のスクリーンショットを撮ったときの連番です。1から始まります。
      */
     val snapShotCounter: AtomicInteger = AtomicInteger(1)
-    private val snapShot: SnapShot = SnapShot()
-    private val snapShotNameCreator: SnapShotNameCreator
+    protected val snapShot: SnapShot = SnapShot()
+    protected val snapShotNameCreator: SnapShotNameCreator
         get() = SnapShotOptions.currentSettings.fileNameCreator
 
     override fun starting() {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
@@ -44,8 +44,8 @@ import kotlin.reflect.KClass
  */
 abstract class ActivityScenarioPage<IMPL, A : AppCompatActivity>(
         uiTestExtension: UiTestExtension<*>,
-        private val activityClass: KClass<A>,
-        @IdRes private val viewIdSearchingNavController: Int? = null
+        val activityClass: KClass<A>,
+        @IdRes val viewIdSearchingNavController: Int? = null
 ) : ActivityOrFragmentScenarioPage<IMPL, A, Nothing>(uiTestExtension) {
 
     val scenario: ActivityScenario<A>

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
@@ -127,8 +127,7 @@ abstract class DialogFragmentPage<IMPL, D : DialogFragment, DH : DialogHostingFr
         val snapShotFileName = snapShotNameCreator.createFileName(
                 snapShotPageName!!, condition, snapShotCounter.getAndIncrement(), optionalDescription)
         onDialogFragment {
-            val view = it.requireDialog().window!!.decorView.rootView
-            snapShot.capture(it, view, snapShotFileName)
+            snapShot.capture(it, snapShotFileName)
         }
     }
 

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
@@ -52,9 +52,9 @@ import kotlin.reflect.KClass
  */
 abstract class DialogFragmentPage<IMPL, D : DialogFragment, DH : DialogHostingFragment, HA>(
         uiTestExtension: UiTestExtension<*>,
-        protected val dialogFragmentClass: KClass<D>,
+        val dialogFragmentClass: KClass<D>,
         @Suppress("UNCHECKED_CAST")
-        protected val dialogHostingFragmentClass: KClass<DH> = DialogHostingFragment::class as KClass<DH>,
+        val dialogHostingFragmentClass: KClass<DH> = DialogHostingFragment::class as KClass<DH>,
         @Suppress("UNCHECKED_CAST")
         hostActivityClass: KClass<HA> = FragmentTestingActivity::class as KClass<HA>,
         hostActivityIntent: Intent = FragmentTestingActivity.createIntent(ApplicationProvider.getApplicationContext())

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
@@ -37,6 +37,10 @@ import kotlin.reflect.KClass
  *
  * 利用例はREADME.mdを参照してください。
  *
+ * [captureActivityOrFragment]メソッドではダイアログの表示内容をキャプチャできません。用途に応じて次のいずれかのメソッド使ってください。
+ * - 画面全体(スクリーン全体)をキャプチャしたいとき: [captureDisplay]
+ * - ダイアログ内に表示されている内容だけをキャプチャしたいとき: [captureDialogFragment]
+ *
  * @param uiTestExtension `RegisterExtension`で登録したUiTestExtensionのインスタンスを指定します。
  * @param dialogFragmentClass 起動したいダイアログフラグメントのクラスを指定します。
  * @param dialogHostingFragmentClass ダイアログフラグメントをホストするフラグメントのクラスを指定します。
@@ -107,7 +111,15 @@ abstract class DialogFragmentPage<IMPL, D : DialogFragment, DH : DialogHostingFr
     fun getSupportMapFragmentHelperOfDialogFragment(@IdRes mapFragmentId: Int? = null) =
             SupportMapFragmentHelper(uiTestExtension, this::onDialogFragment, mapFragmentId)
 
-
+    /**
+     * このダイアログ内に表示されている内容全体(画面全体ではない)をキャプチャします。
+     * 画面全体をキャプチャしたいときは[captureDisplay]を使ってください。
+     *
+     * @param condition キャプチャ時点の画面の状態を表す文字列を指定します。結果レポートに表示されます。
+     * @param optionalDescription その他、結果レポートに表示させたい補足事項があれば、それを指定します。
+     *   `null`以外が指定された場合は結果レポートに表示されます。
+     * @param waitUntilIdle キャプチャする前にアイドル状態になるまで待つ場合には`true`を、そうでない場合は`false`を指定します。
+     */
     fun captureDialogFragment(condition: String, optionalDescription: String? = null, waitUntilIdle: Boolean = true) {
         if (waitUntilIdle) {
             Espresso.onIdle()
@@ -128,6 +140,8 @@ abstract class DialogFragmentPage<IMPL, D : DialogFragment, DH : DialogHostingFr
      * @throws UnsupportedOperationException [dialogHostingFragmentClass]コンストラクタ引数にKotlinで表現できない型が宣言されているとき (おそらく発生することはない)
      * @throws IllegalArgumentException [dialogHostingFragmentClass]コンストタクタのいずれかの引数の型がインターフェイスではないとき
      */
+    // `constructors`, `parameters`, `type`, `call`いずれもkotlin-reflect.jarが無くても呼べるのだが、何故か警告が出てしまうので抑止。
+    @Suppress("NO_REFLECTION_IN_CLASS_PATH")
     fun <DH : DialogHostingFragment> newDialogHostingFragment(dialogHostingFragmentClass: KClass<DH>): DH {
         // 厳密にはこれでprimary constructorが取れる保証はない。
         // とはいえ、テストコード上で宣言するDialogHostingFragmentのサブクラスで変なコンストラクタを宣言するケースも考えられないので、これで妥協する。

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
@@ -52,10 +52,10 @@ import kotlin.reflect.KClass
  */
 abstract class FragmentScenarioPage<IMPL, F : Fragment, HA>(
         uiTestExtension: UiTestExtension<*>,
-        private val fragmentClass: KClass<F>,
+        val fragmentClass: KClass<F>,
         @Suppress("UNCHECKED_CAST")
-        private val hostActivityClass: KClass<HA> = FragmentTestingActivity::class as KClass<HA>,
-        private val hostActivityIntent: Intent = FragmentTestingActivity.createIntent(ApplicationProvider.getApplicationContext()),
+        val hostActivityClass: KClass<HA> = FragmentTestingActivity::class as KClass<HA>,
+        val hostActivityIntent: Intent = FragmentTestingActivity.createIntent(ApplicationProvider.getApplicationContext()),
         @IdRes val contentLayoutId: Int? = null
 ) : ActivityOrFragmentScenarioPage<IMPL, HA, F>(uiTestExtension)
         where HA : AppCompatActivity, HA : TestingFragmentHost {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShot.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShot.kt
@@ -24,6 +24,8 @@ import android.os.Handler
 import android.util.Log
 import android.view.PixelCopy
 import android.view.View
+import android.view.Window
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
@@ -62,22 +64,30 @@ class SnapShot {
         capture(fragment.requireActivity(), view, name)
     }
 
+    fun capture(dialogFragment: DialogFragment, view: View, name: String) {
+        captureView(view, dialogFragment.requireDialog().window) {
+            saveBitMap(it, name)
+        }
+    }
+
     fun capture(activity: Activity, view: View, name: String) {
         captureView(view, activity) {
             saveBitMap(it, name)
         }
     }
 
-    private fun captureView(view: View, activity: Activity, callback: (Bitmap) -> Unit) {
+    private fun captureView(view: View, activity: Activity, callback: (Bitmap) -> Unit) = captureView(view, activity.window, callback)
 
-        activity.window?.let { window ->
+    private fun captureView(view: View, window: Window?, callback: (Bitmap) -> Unit) {
+
+        window?.let { _window ->
             val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
 
             val viewLocation = IntArray(2)
             view.getLocationInWindow(viewLocation)
 
             PixelCopy.request(
-                    window,
+                    _window,
                     Rect(
                             viewLocation[0],
                             viewLocation[1],

--- a/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShot.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/snapshot/SnapShot.kt
@@ -60,19 +60,23 @@ class SnapShot {
         capture(fragment.requireActivity(), fragment.requireView(), name)
     }
 
+    fun capture(dialogFragment: DialogFragment, name: String) {
+        capture(dialogFragment, dialogFragment.requireDialog().window!!.decorView.rootView, name)
+    }
+
     fun capture(fragment: Fragment, view: View, name: String) {
         capture(fragment.requireActivity(), view, name)
     }
 
     fun capture(dialogFragment: DialogFragment, view: View, name: String) {
         captureView(view, dialogFragment.requireDialog().window) {
-            saveBitMap(it, name)
+            saveBitmap(it, name)
         }
     }
 
     fun capture(activity: Activity, view: View, name: String) {
         captureView(view, activity) {
-            saveBitMap(it, name)
+            saveBitmap(it, name)
         }
     }
 
@@ -108,7 +112,7 @@ class SnapShot {
         }
     }
 
-    private fun saveBitMap(bitmap: Bitmap, name: String) {
+    fun saveBitmap(bitmap: Bitmap, name: String) {
 
         val imageFile = captureFile(name)
         var out: BufferedOutputStream? = null


### PR DESCRIPTION
fixes #15 

- DialogFragmentPageに、(画面全体ではなく)DialogFragment全体をキャプチャするメソッド `captureDialogFragment`を追加します。
- サブクラスでカスタマイズしやすいように、いくつかの関数・プロパティの可視性を広げ、上書きされる可能性のある関数をopenにします。

## 注意事項
以下のクラスのプロパティのうち、いくつかを`private`から`public`にしています。
その関係で、サブクラス側で同名プロパティを宣言しているとコンパイルエラーになります。
その場合はプロパティの名前を換えるか、単純にスーパークラスで宣言されているプロパティを使うか、いずれかの方法で回避をお願いします。

- `ActivityOrFragmentScenarioPage`
- `ActivityScenarioPage`
- `DialogFragmentPage`
