### PR TITLE
androidx.fragment:fragment-testingへの依存関係削除

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -41,8 +41,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "androidx.test:rules:$androidxTestVersion"
-    //noinspection FragmentGradleConfiguration
-    implementation "androidx.fragment:fragment-testing:$fragmentVersion"
+    implementation "androidx.test:core-ktx:$androidxTestVersion"
     implementation "androidx.test.uiautomator:uiautomator:$uiautomatorVersion"
     implementation "androidx.test.espresso:espresso-core:$espressoVersion"
     implementation "androidx.test.espresso:espresso-contrib:$espressoVersion"

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
@@ -23,7 +23,6 @@ import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
-import androidx.fragment.app.testing.FragmentScenario
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.test.core.app.ApplicationProvider
@@ -39,7 +38,7 @@ import com.google.android.gms.maps.SupportMapFragment
 import kotlin.reflect.KClass
 
 /**
- * [androidx.fragment.app.testing.FragmentScenario]を使って画面を起動するPage実装です。
+ * [AppCompatFragmentScenario]を使って画面を起動するPage実装です。
  * @param IMPL 実装クラスの型
  * @param F FragmentScenarioを使って起動するFragmentの型
  * @param HA 起動するFragmentをホストするActivityの型


### PR DESCRIPTION
gogo-screenshot-androidでは、独自に実装したFragmentScenarioを使っているにもかかわらず
`androidx.fragment:fragment-testing`
を依存関係に含めていましたので削除しました。

`fragment-testing`を削除したところ、`ActivityScenario`が参照できなくなったため、
依存関係に`androidx.test:core-ktx`を加えました。

AndroidX Test関連のバージョン最新化については、別途検討したいと思います。

