### PR TITLE
MoT の Github の IP 制限に対応する TORONTO を走らせるように

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name  == 'pull_request' # if only run pull request when multiple trigger workflow
     steps:
+      - name: Install toronto-cli
+        env:
+          TORONTO_CLI_VERSION: 1.0.0
+        run: |
+          # install toronto-cli
+          curl -LO https://toronto-cli-5d506707-9097-443c-bbf7-f15775d84c68.s3.ap-northeast-1.amazonaws.com/${TORONTO_CLI_VERSION}/toronto-cli-linux-386.tar.gz
+          tar -xzf toronto-cli-linux-386.tar.gz
+          mv toronto-cli-linux-386 toronto-cli
+          chmod +x toronto-cli
+          rm -r toronto-cli-linux-386.tar.gz
+      - name: Run toronto-cli
+        env:
+          MOT_TORONTO_TOKEN: ${{ secrets.TORONTO_TOKEN }}
+        run: |
+          # run toronto-cli
+          ./toronto-cli
+
+          # cleanup
+          rm ./toronto-cli
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:


### PR DESCRIPTION
MoT の Github に IP 制限が導入されるに伴って checkout 等が動かなくなるため、一時的に IP 制限を解除する内製アプリ Toronto を走らせるように