### PR TITLE
launch系・capture系のメソッドをopenにした

### DIFF
--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
@@ -131,7 +131,9 @@ abstract class ActivityScenarioPage<IMPL, A : AppCompatActivity>(
      * @param intent 目的のFragmentの親Activityを起動するのに必要なIntentを指定します。
      * @param navigateAction 目的のFragmentを起動するために必要な処理を指定します。`null`が指定されている場合は何もしません。
      */
-    open fun launchFragmentByNavController(@IdRes fragmentDestination: Int, intent: Intent? = null, navigateAction: ((NavController) -> Unit)? = null) {
+    open fun launchFragmentByNavController(@IdRes fragmentDestination: Int,
+                                           intent: Intent? = null,
+                                           navigateAction: ((NavController) -> Unit)? = null) {
         checkNotNull(viewIdSearchingNavController)
         // Fragment名を取る方法がわからないので、destination IDから画面名を生成する
         if (snapShotPageName == null) {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
@@ -60,7 +60,7 @@ abstract class ActivityScenarioPage<IMPL, A : AppCompatActivity>(
      *
      * @param intent [activityClass]を起動するのに必要なIntentを指定します。
      */
-    fun launchActivitySimply(intent: Intent? = null) {
+    open fun launchActivitySimply(intent: Intent? = null) {
         if (snapShotPageName == null) {
             snapShotPageName = activityClass.java.simpleName
         }
@@ -131,7 +131,7 @@ abstract class ActivityScenarioPage<IMPL, A : AppCompatActivity>(
      * @param intent 目的のFragmentの親Activityを起動するのに必要なIntentを指定します。
      * @param navigateAction 目的のFragmentを起動するために必要な処理を指定します。`null`が指定されている場合は何もしません。
      */
-    fun launchFragmentByNavController(@IdRes fragmentDestination: Int, intent: Intent? = null, navigateAction: ((NavController) -> Unit)? = null) {
+    open fun launchFragmentByNavController(@IdRes fragmentDestination: Int, intent: Intent? = null, navigateAction: ((NavController) -> Unit)? = null) {
         checkNotNull(viewIdSearchingNavController)
         // Fragment名を取る方法がわからないので、destination IDから画面名を生成する
         if (snapShotPageName == null) {

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/ActivityScenarioPage.kt
@@ -177,7 +177,7 @@ abstract class ActivityScenarioPage<IMPL, A : AppCompatActivity>(
      * @param waitUntilIdle キャプチャする前にアイドル状態になるまで待つ場合には`true`を、そうでない場合は`false`を指定します。
      * @param func キャプチャ対象を返す関数を指定します。この関数の引数には、画面に表示されているActivityが渡されます。
      */
-    fun captureView(condition: String, optionalDescription: String?, waitUntilIdle: Boolean, func: (A) -> View) {
+    open fun captureView(condition: String, optionalDescription: String?, waitUntilIdle: Boolean, func: (A) -> View) {
         captureViewFromActivityOrFragment(condition, optionalDescription, waitUntilIdle) {
             when (it) {
                 is ActivityOrFragment.Activity -> func(it.activity)

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/DialogFragmentPage.kt
@@ -120,7 +120,7 @@ abstract class DialogFragmentPage<IMPL, D : DialogFragment, DH : DialogHostingFr
      *   `null`以外が指定された場合は結果レポートに表示されます。
      * @param waitUntilIdle キャプチャする前にアイドル状態になるまで待つ場合には`true`を、そうでない場合は`false`を指定します。
      */
-    fun captureDialogFragment(condition: String, optionalDescription: String? = null, waitUntilIdle: Boolean = true) {
+    open fun captureDialogFragment(condition: String, optionalDescription: String? = null, waitUntilIdle: Boolean = true) {
         if (waitUntilIdle) {
             Espresso.onIdle()
         }

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
@@ -227,7 +227,7 @@ abstract class FragmentScenarioPage<IMPL, F : Fragment, HA>(
      * @param waitUntilIdle キャプチャする前にアイドル状態になるまで待つ場合には`true`を、そうでない場合は`false`を指定します。
      * @param func キャプチャ対象を返す関数を指定します。この関数の引数には、画面に表示されているFragmentが渡されます。
      */
-    fun captureView(condition: String, optionalDescription: String?, waitUntilIdle: Boolean, func: (F) -> View) {
+    open fun captureView(condition: String, optionalDescription: String?, waitUntilIdle: Boolean, func: (F) -> View) {
         captureViewFromActivityOrFragment(condition, optionalDescription, waitUntilIdle) {
             when (it) {
                 is ActivityOrFragment.Fragment -> func(it.fragment)

--- a/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
+++ b/library/src/main/java/app/mobilitytechnologies/uitest/page/FragmentScenarioPage.kt
@@ -75,7 +75,7 @@ abstract class FragmentScenarioPage<IMPL, F : Fragment, HA>(
      * @param factory 起動するFragmentを生成するためのファクトリーを指定します。
      *   [AppCompatFragmentScenario.launchInContainer]の引数にそのまま渡されます。
      */
-    fun launchFragmentSimply(fragmentArgs: Bundle? = null, factory: FragmentFactory? = null) {
+    open fun launchFragmentSimply(fragmentArgs: Bundle? = null, factory: FragmentFactory? = null) {
         if (snapShotPageName == null) {
             snapShotPageName = fragmentClass.java.simpleName
         }
@@ -88,7 +88,7 @@ abstract class FragmentScenarioPage<IMPL, F : Fragment, HA>(
      *
      * @param fragmentCreator 起動したいFragmentをインスタンス化する処理が書かれたλ式を指定します。
      */
-    fun launchFragmentByCreator(fragmentCreator: () -> F) {
+    open fun launchFragmentByCreator(fragmentCreator: () -> F) {
         launchFragmentSimply(factory = object : FragmentFactory() {
             override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
                 return if (className == fragmentClass.java.name) {
@@ -130,7 +130,7 @@ abstract class FragmentScenarioPage<IMPL, F : Fragment, HA>(
      * @param navigateAction 目的の子Fragmentを起動するためにNavControllerに対して何らかの操作が必要な場合、その操作内容を指定します。
      *   `null`が指定された場合は何もしません。
      */
-    fun launchChildFragmentByNavController(@IdRes fragmentDestination: Int,
+    open fun launchChildFragmentByNavController(@IdRes fragmentDestination: Int,
                                            fragmentArgs: Bundle? = null,
                                            factory: FragmentFactory? = null,
                                            navigateAction: ((NavController) -> Unit)? = null) {


### PR DESCRIPTION
サブクラス側でのカスタマイズを容易にするため、以下のクラスの `launch`系と `capture`系のメソッドをopenにしました。
振舞いの変更はありません。

- ActivityScenarioPage
- FragmentScenarioPage
- DialogFragmentPage