### PR TITLE
GitHub ActionsでGitHub Packagesにpublishするworkflowを書いた

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'publishするバージョン (デフォルトでブランチ名のSNAPSHOTとcommit idが作られます)'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: publish-explicit-version
+        if: github.event.inputs.version != ''
+        run: |
+          ./gradlew -Pversion=$PUBLISH_VERSION build publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_VERSION: ${{ github.event.inputs.version }}
+      - name: publish-snapshots
+        if: github.event.inputs.version == ''
+        run: |
+          VERSION_COMMIT_SHA=$(git rev-parse --short @)
+          BRANCH=$(git rev-parse --abbrev-ref @)
+          VERSION_BRANCH=${BRANCH////\~}-SNAPSHOT
+          ./gradlew -Pversion=$VERSION_COMMIT_SHA build publish
+          ./gradlew -Pversion=$VERSION_BRANCH publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -73,7 +73,8 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
 
-                // group と version は jitpack が自動的に付けてくれる
+                // -Pversion=xxxxx を実行時に渡して、publishするバージョンを指定してください。
+                group = 'com.github.MobilityTechnologies'
                 artifactId = 'gogo-screenshot-android'
                 pom {
                     name = 'GOGO Screenshot Test for Android'
@@ -97,6 +98,16 @@ afterEvaluate {
                         developerConnection = 'scm:git://github.com/MobilityTechnologies/gogo-screenshot-android.git'
                         url = 'git://github.com/MobilityTechnologies/gogo-screenshot-android.git'
                     }
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = 'GitHubPackages'
+                url "https://maven.pkg.github.com/MobilityTechnologies/gogo-screenshot-android"
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR")
+                    password = System.getenv("GITHUB_TOKEN")
                 }
             }
         }


### PR DESCRIPTION
GitHub Actionsで、GitHub Packagesにpublishするworkflowを書きました。
- publishするバージョンを指定して手動で実行できます
- pushトリガーでも自動的に実行されます。その場合はbranch名のSNAPSHOTとcommit-shaをpublishします。